### PR TITLE
Fix py2 to py3 issue in crefi_helper.py

### DIFF
--- a/crefi_helper.py
+++ b/crefi_helper.py
@@ -96,7 +96,10 @@ def create_tar_file(fil, size, mins, maxs, rand):
 
 def get_filename(flen):
     size = flen
-    char = string.uppercase+string.digits
+    try:
+        char = string.uppercase + string.digits
+    except AttributeError:
+        char = string.ascii_uppercase + string.digits
     st = ''.join(random.choice(char) for i in range(size))
     ti = str((hex(int(str(time.time()).split('.')[0])))[2:])
     return ti+"%%"+st
@@ -160,7 +163,10 @@ def tar_files(files, file_count, inter, size, mins, maxs,
 
 
 def setxattr_files(files, randname, dir_path):
-    char = string.uppercase+string.digits
+    try:
+        char = string.uppercase + string.digits
+    except AttributeError:
+        char = string.ascii_uppercase + string.digits
     if not randname:
         for k in range(files):
             v = ''.join(random.choice(char) for i in range(10))


### PR DESCRIPTION
Problem:
Crefi fails with the below traceback when tried to run
using python3:
```
Traceback (most recent call last):
2020-06-22 16:52:24,172 - thread-2: Entering the directory level00
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.6/site-packages/crefi-2.0.8-py3.6.egg/crefi_helper.py", line 349, in multipledir
    dir_path)
  File "/usr/local/lib/python3.6/site-packages/crefi-2.0.8-py3.6.egg/crefi_helper.py", line 114, in text_files
    fil = dir_path+"/"+get_filename(flen)
  File "/usr/local/lib/python3.6/site-packages/crefi-2.0.8-py3.6.egg/crefi_helper.py", line 99, in get_filename
    char = string.uppercase+string.digits
AttributeError: module 'string' has no attribute 'uppercase'
```

This is because in python3 `string.uppercase` is changed to
`string.ascii_uppercase`.

Fix:
Adding code to handle this in both python2 and python3

Signed-off-by: kshithijiyer <kshithij.ki@gmail.com>